### PR TITLE
fix: shutdown executor to properly stop the server

### DIFF
--- a/src/main/kotlin/com/github/p1k0chu/mcmod/bac_tracker/Main.kt
+++ b/src/main/kotlin/com/github/p1k0chu/mcmod/bac_tracker/Main.kt
@@ -150,7 +150,7 @@ object Main : ModInitializer {
             )
         }
 
-        ServerLifecycleEvents.SERVER_STOPPING.register { _ ->
+        ServerLifecycleEvents.SERVER_STOPPING.register { server: MinecraftServer ->
             // "free" memory of unused objects
             advMap = null
             statMap = null
@@ -164,7 +164,9 @@ object Main : ModInitializer {
             scheduledExecutor?.shutdown()
             scheduledExecutor = null
 
-            executor.shutdown()
+            if(server.isDedicated){
+                executor.shutdown()
+            }
 
             this.state = State.NOT_INITIALIZED
         }

--- a/src/main/kotlin/com/github/p1k0chu/mcmod/bac_tracker/Main.kt
+++ b/src/main/kotlin/com/github/p1k0chu/mcmod/bac_tracker/Main.kt
@@ -164,6 +164,8 @@ object Main : ModInitializer {
             scheduledExecutor?.shutdown()
             scheduledExecutor = null
 
+            executor.shutdown()
+
             this.state = State.NOT_INITIALIZED
         }
 


### PR DESCRIPTION
Right now, the server will just hang forever after I input the `stop` command. This is due to the `executor` not properly shutdown, and thus, the thread is not yet joined.