### PR TITLE
fix(Utils): correctly handle non-URL sheet ID

### DIFF
--- a/src/main/kotlin/com/github/p1k0chu/mcmod/bac_tracker/utils/Utils.kt
+++ b/src/main/kotlin/com/github/p1k0chu/mcmod/bac_tracker/utils/Utils.kt
@@ -30,8 +30,11 @@ object Utils {
 
     fun getIdOrUrl(str: String): String {
         val m = googleSheetUrlRegex.matcher(str)
-        m.find()
-        return m.group("id") ?: str
+        return if (m.find()) {
+            m.group("id")
+        } else {
+            str
+        }
     }
 
     /**


### PR DESCRIPTION
`Matcher.group()` will throw `IllegalStateException` if the matching fails. This commit gracefully handles the case where `Matcher` fails (i.e. only the ID is provided).